### PR TITLE
Add filterprocessor for filtering metrics by metrics name

### DIFF
--- a/internal/processor/filtermetric/config.go
+++ b/internal/processor/filtermetric/config.go
@@ -22,7 +22,7 @@ import (
 // type of string pattern matching to use.
 type MatchProperties struct {
 	// MatchConfig configures the matching patterns used when matching metric properties.
-	MatchConfig factory.MatchConfig `mapstructure:",squash"`
+	factory.MatchConfig `mapstructure:",squash"`
 
 	// MetricNames specifies the list of string patterns to match metric names against.
 	// A match occurs if the metric name matches at least one string pattern in this list.

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -1,0 +1,39 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/internal/processor/filtermetric"
+)
+
+// Config defines configuration for Resource processor.
+type Config struct {
+	configmodels.ProcessorSettings `mapstructure:",squash"`
+	Metrics                        MetricFilters `mapstructure:"metrics"`
+}
+
+// MetricFilter filters by Metric properties.
+type MetricFilters struct {
+	// Include match properties describe metrics that should be included in the Collector Service pipeline,
+	// all other metrics should be dropped from further processing.
+	// If both Include and Exclude are specified, Include filtering occurs first.
+	Include *filtermetric.MatchProperties `mapstructure:"include"`
+
+	// Exclude match properties describe metrics that should be excluded from the Collector Service pipeline,
+	// all other metrics should be included.
+	// If both Include and Exclude are specified, Include filtering occurs first.
+	Exclude *filtermetric.MatchProperties `mapstructure:"exclude"`
+}

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -1,0 +1,259 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/internal/processor/filtermetric"
+	fsfactory "github.com/open-telemetry/opentelemetry-collector/internal/processor/filterset/factory"
+)
+
+// TestLoadingConfigRegexp tests loading testdata/config_strict.yaml
+func TestLoadingConfigStrict(t *testing.T) {
+	// list of filters used repeatedly on testdata/config_strict.yaml
+	testDataFilters := []string{
+		"hello_world",
+		"hello/world",
+	}
+
+	testDataMetricProperties := &filtermetric.MatchProperties{
+		MatchConfig: fsfactory.MatchConfig{
+			MatchType: fsfactory.STRICT,
+		},
+		MetricNames: testDataFilters,
+	}
+
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Processors[typeStr] = factory
+	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config_strict.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, config)
+
+	tests := []struct {
+		filterName string
+		expCfg     *Config
+	}{
+		{
+			filterName: "filter/empty",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/empty",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: &filtermetric.MatchProperties{
+						MatchConfig: fsfactory.MatchConfig{
+							MatchType: fsfactory.STRICT,
+						},
+					},
+				},
+			},
+		}, {
+			filterName: "filter/include",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/include",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: testDataMetricProperties,
+				},
+			},
+		}, {
+			filterName: "filter/exclude",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/exclude",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Exclude: testDataMetricProperties,
+				},
+			},
+		}, {
+			filterName: "filter/includeexclude",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/includeexclude",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: testDataMetricProperties,
+					Exclude: &filtermetric.MatchProperties{
+						MatchConfig: fsfactory.MatchConfig{
+							MatchType: fsfactory.STRICT,
+						},
+						MetricNames: []string{"hello_world"},
+					},
+				},
+			},
+		}, {
+			filterName: "filter/strictwithconfig",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/strictwithconfig",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: testDataMetricProperties,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterName, func(t *testing.T) {
+			cfg := config.Processors[test.filterName]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
+// TestLoadingConfigRegexp tests loading testdata/config_regexp.yaml
+func TestLoadingConfigRegexp(t *testing.T) {
+	// list of filters used repeatedly on testdata/config.yaml
+	testDataFilters := []string{
+		"prefix/.*",
+		"prefix_.*",
+		".*/suffix",
+		".*_suffix",
+		".*/contains/.*",
+		".*_contains_.*",
+		"full/name/match",
+		"full_name_match",
+	}
+
+	testDataMetricProperties := &filtermetric.MatchProperties{
+		MatchConfig: fsfactory.MatchConfig{
+			MatchType: fsfactory.REGEXP,
+		},
+		MetricNames: testDataFilters,
+	}
+
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Processors[typeStr] = factory
+	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config_regexp.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, config)
+
+	tests := []struct {
+		filterName string
+		expCfg     *Config
+	}{
+		{
+			filterName: "filter/include",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/include",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: testDataMetricProperties,
+				},
+			},
+		}, {
+			filterName: "filter/exclude",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/exclude",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Exclude: testDataMetricProperties,
+				},
+			},
+		}, {
+			filterName: "filter/unlimitedcache",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/unlimitedcache",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: &filtermetric.MatchProperties{
+						MatchConfig: fsfactory.MatchConfig{
+							MatchType: fsfactory.REGEXP,
+							Regexp: &fsfactory.RegexpConfig{
+								CacheEnabled: true,
+							},
+						},
+						MetricNames: testDataFilters,
+					},
+				},
+			},
+		}, {
+			filterName: "filter/limitedcache",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/limitedcache",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Exclude: &filtermetric.MatchProperties{
+						MatchConfig: fsfactory.MatchConfig{
+							MatchType: fsfactory.REGEXP,
+							Regexp: &fsfactory.RegexpConfig{
+								CacheEnabled:       true,
+								CacheMaxNumEntries: 10,
+							},
+						},
+						MetricNames: testDataFilters,
+					},
+				},
+			},
+		}, {
+			filterName: "filter/fullmatchrequired",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "filter/fullmatchrequired",
+					TypeVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Exclude: &filtermetric.MatchProperties{
+						MatchConfig: fsfactory.MatchConfig{
+							MatchType: fsfactory.REGEXP,
+							Regexp: &fsfactory.RegexpConfig{
+								FullMatchRequired: true,
+							},
+						},
+						MetricNames: testDataFilters,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterName, func(t *testing.T) {
+			cfg := config.Processors[test.filterName]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}

--- a/processor/filterprocessor/doc.go
+++ b/processor/filterprocessor/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filterprocessor implements a processor for filtering
+// (dropping) metrics data by metric properties.
+package filterprocessor

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -1,0 +1,67 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "filter"
+)
+
+// Factory is the factory for filter processor.
+type Factory struct {
+}
+
+// Type gets the type of the Option config created by this factory.
+func (f *Factory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for processor.
+func (f *Factory) CreateDefaultConfig() configmodels.Processor {
+	return &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+// CreateTraceProcessor creates a trace processor based on this config.
+func (f *Factory) CreateTraceProcessor(
+	logger *zap.Logger,
+	nextConsumer consumer.TraceConsumerOld,
+	c configmodels.Processor,
+) (component.TraceProcessorOld, error) {
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+// CreateMetricsProcessor creates a metrics processor based on this config.
+func (f *Factory) CreateMetricsProcessor(
+	logger *zap.Logger,
+	nextConsumer consumer.MetricsConsumerOld,
+	cfg configmodels.Processor,
+) (component.MetricsProcessorOld, error) {
+	oCfg := cfg.(*Config)
+	return newFilterMetricProcessor(nextConsumer, oCfg)
+}

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+func TestFactory_Type(t *testing.T) {
+	factory := Factory{}
+	assert.Equal(t, factory.Type(), typeStr)
+}
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.Equal(t, cfg, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			NameVal: typeStr,
+			TypeVal: typeStr,
+		},
+	})
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+}
+
+func TestFactory_CreateProcessors(t *testing.T) {
+	tests := []struct {
+		configName string
+		succeed    bool
+	}{
+		{
+			configName: "config_regexp.yaml",
+			succeed:    true,
+		}, {
+			configName: "config_strict.yaml",
+			succeed:    true,
+		}, {
+			configName: "config_invalid.yaml",
+			succeed:    false,
+		},
+	}
+
+	for _, test := range tests {
+		factories, err := config.ExampleComponents()
+		assert.Nil(t, err)
+
+		factory := &Factory{}
+		factories.Processors[typeStr] = factory
+		config, err := config.LoadConfigFile(t, path.Join(".", "testdata", test.configName), factories)
+
+		for name, cfg := range config.Processors {
+			t.Run(fmt.Sprintf("%s/%s", test.configName, name), func(t *testing.T) {
+				tp, tErr := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
+				// Not implemented error
+				assert.NotNil(t, tErr)
+				assert.Nil(t, tp)
+
+				mp, mErr := factory.CreateMetricsProcessor(zap.NewNop(), nil, cfg)
+				assert.Equal(t, test.succeed, mp != (*filterMetricProcessor)(nil))
+				assert.Equal(t, test.succeed, mErr == nil)
+			})
+		}
+	}
+}

--- a/processor/filterprocessor/filtermetricprocessor.go
+++ b/processor/filterprocessor/filtermetricprocessor.go
@@ -1,0 +1,123 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/processor/filtermetric"
+)
+
+type filterMetricProcessor struct {
+	cfg          *Config
+	capabilities component.ProcessorCapabilities
+	next         consumer.MetricsConsumerOld
+	include      *filtermetric.Matcher
+	exclude      *filtermetric.Matcher
+}
+
+var _ component.MetricsProcessorOld = (*filterMetricProcessor)(nil)
+
+func newFilterMetricProcessor(next consumer.MetricsConsumerOld, cfg *Config) (*filterMetricProcessor, error) {
+	inc, err := createMatcher(cfg.Metrics.Include)
+	if err != nil {
+		return nil, err
+	}
+
+	exc, err := createMatcher(cfg.Metrics.Exclude)
+	if err != nil {
+		return nil, err
+	}
+
+	return &filterMetricProcessor{
+		cfg:          cfg,
+		capabilities: component.ProcessorCapabilities{MutatesConsumedData: false},
+		next:         next,
+		include:      inc,
+		exclude:      exc,
+	}, nil
+}
+
+func createMatcher(mp *filtermetric.MatchProperties) (*filtermetric.Matcher, error) {
+	// Nothing specified in configuration
+	if mp == nil {
+		return nil, nil
+	}
+
+	matcher, err := filtermetric.NewMatcher(mp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &matcher, nil
+}
+
+// GetCapabilities returns the Capabilities assocciated with the resource processor.
+func (fmp *filterMetricProcessor) GetCapabilities() component.ProcessorCapabilities {
+	return fmp.capabilities
+}
+
+// Start is invoked during service startup.
+func (*filterMetricProcessor) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+// Shutdown is invoked during service shutdown.
+func (*filterMetricProcessor) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+// ConsumeMetricsData implements the MetricsProcessor interface
+func (fmp *filterMetricProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	return fmp.next.ConsumeMetricsData(ctx, consumerdata.MetricsData{
+		Node:     md.Node,
+		Resource: md.Resource,
+		Metrics:  fmp.filterMetrics(md.Metrics),
+	})
+}
+
+// filterMetrics filters the given spans based off the filterMetricProcessor's filters.
+func (fmp *filterMetricProcessor) filterMetrics(metrics []*metricspb.Metric) []*metricspb.Metric {
+	keep := []*metricspb.Metric{}
+	for _, m := range metrics {
+		if fmp.shouldKeepMetric(m) {
+			keep = append(keep, m)
+		}
+	}
+
+	return keep
+}
+
+// shouldKeepMetric determines whether a metric should be kept based off the filterMetricProcessor's filters.
+func (fmp *filterMetricProcessor) shouldKeepMetric(metric *metricspb.Metric) bool {
+	if fmp.include != nil {
+		if !fmp.include.MatchMetric(metric) {
+			return false
+		}
+	}
+
+	if fmp.exclude != nil {
+		if fmp.exclude.MatchMetric(metric) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/processor/filterprocessor/filtermetricprocessor_test.go
+++ b/processor/filterprocessor/filtermetricprocessor_test.go
@@ -1,0 +1,196 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+	"testing"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/processor/filtermetric"
+	fsfactory "github.com/open-telemetry/opentelemetry-collector/internal/processor/filterset/factory"
+	ptest "github.com/open-telemetry/opentelemetry-collector/processor/processortest"
+)
+
+var (
+	validFilters = []string{
+		"prefix/.*",
+		"prefix_.*",
+		".*/suffix",
+		".*_suffix",
+		".*/contains/.*",
+		".*_contains_.*",
+		"full/name/match",
+		"full_name_match",
+	}
+)
+
+func createFilterProcessorConfig(matchType fsfactory.MatchType, inc []string, exc []string) *Config {
+	return &Config{}
+
+}
+
+func TestFilterMetricProcessor(t *testing.T) {
+	inMetricNames := []string{
+		"full_name_match",
+		"not_exact_string_match",
+		"prefix/test/match",
+		"prefix_test_match",
+		"wrongprefix/test/match",
+		"test/match/suffix",
+		"test_match_suffix",
+		"test/match/suffixwrong",
+		"test/contains/match",
+		"test_contains_match",
+		"random",
+		"full/name/match",
+		"full_name_match", // repeats
+		"not_exact_string_match",
+	}
+
+	regexpMetricsFilterProperties := &filtermetric.MatchProperties{
+		MatchConfig: fsfactory.MatchConfig{
+			MatchType: fsfactory.REGEXP,
+			Regexp: &fsfactory.RegexpConfig{
+				FullMatchRequired: true,
+			},
+		},
+		MetricNames: validFilters,
+	}
+
+	tests := []struct {
+		name  string
+		cfg   *Config
+		inc   *filtermetric.MatchProperties
+		exc   *filtermetric.MatchProperties
+		inMN  []string // input Metric names
+		outMN []string // output Metric names
+	}{
+		{
+			name: "includeFilter",
+			inc:  regexpMetricsFilterProperties,
+			inMN: inMetricNames,
+			outMN: []string{
+				"full_name_match",
+				"prefix/test/match",
+				"prefix_test_match",
+				"test/match/suffix",
+				"test_match_suffix",
+				"test/contains/match",
+				"test_contains_match",
+				"full/name/match",
+				"full_name_match",
+			},
+		}, {
+			name: "excludeFilter",
+			exc:  regexpMetricsFilterProperties,
+			inMN: inMetricNames,
+			outMN: []string{
+				"not_exact_string_match",
+				"wrongprefix/test/match",
+				"test/match/suffixwrong",
+				"random",
+				"not_exact_string_match",
+			},
+		}, {
+			name: "includeAndExclude",
+			inc:  regexpMetricsFilterProperties,
+			exc: &filtermetric.MatchProperties{
+				MatchConfig: fsfactory.MatchConfig{
+					MatchType: fsfactory.STRICT,
+				},
+				MetricNames: []string{
+					"prefix_test_match",
+					"test_contains_match",
+				},
+			},
+			inMN: inMetricNames,
+			outMN: []string{
+				"full_name_match",
+				"prefix/test/match",
+				// "prefix_test_match", excluded by exclude filter
+				"test/match/suffix",
+				"test_match_suffix",
+				"test/contains/match",
+				// "test_contains_match", excluded by exclude filter
+				"full/name/match",
+				"full_name_match",
+			},
+		}, {
+			name: "emptyFilterInclude",
+			inc: &filtermetric.MatchProperties{
+				MatchConfig: fsfactory.MatchConfig{
+					MatchType: fsfactory.STRICT,
+				},
+			},
+			inMN:  inMetricNames,
+			outMN: []string{},
+		}, {
+			name: "emptyFilterExclude",
+			exc: &filtermetric.MatchProperties{
+				MatchConfig: fsfactory.MatchConfig{
+					MatchType: fsfactory.STRICT,
+				},
+			},
+			inMN:  inMetricNames,
+			outMN: inMetricNames,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// next stores the results of the filter metric processor
+			next := &ptest.CachingMetricsConsumer{}
+			cfg := &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+				Metrics: MetricFilters{
+					Include: test.inc,
+					Exclude: test.exc,
+				},
+			}
+			fmp, err := newFilterMetricProcessor(next, cfg)
+			assert.NotNil(t, fmp)
+			assert.Nil(t, err)
+
+			md := consumerdata.MetricsData{
+				Metrics: make([]*metricspb.Metric, len(test.inMN)),
+			}
+
+			for idx, in := range test.inMN {
+				md.Metrics[idx] = &metricspb.Metric{
+					MetricDescriptor: &metricspb.MetricDescriptor{
+						Name: in,
+					},
+				}
+			}
+
+			cErr := fmp.ConsumeMetricsData(context.Background(), md)
+			assert.Nil(t, cErr)
+
+			require.Equal(t, len(test.outMN), len(next.Data.Metrics))
+			for idx, out := range next.Data.Metrics {
+				assert.Equal(t, test.outMN[idx], out.MetricDescriptor.Name)
+			}
+		})
+	}
+}

--- a/processor/filterprocessor/testdata/config_invalid.yaml
+++ b/processor/filterprocessor/testdata/config_invalid.yaml
@@ -1,0 +1,26 @@
+receivers:
+    examplereceiver:
+
+processors:
+    filter/include:
+        # any names NOT matching filters are excluded from remainder of pipeline
+        metrics:
+            include:
+                match_type: regexp
+                metric_names:
+                    # re2 regexp patterns
+                    - (\W|^)stock\stips(\W|$
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [filter/include]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [filter/include]
+            exporters: [exampleexporter]

--- a/processor/filterprocessor/testdata/config_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_regexp.yaml
@@ -1,0 +1,94 @@
+receivers:
+    examplereceiver:
+
+processors:
+    filter:
+    filter/include:
+        # any names NOT matching filters are excluded from remainder of pipeline
+        metrics:
+            include:
+                match_type: regexp
+                metric_names:
+                    # re2 regexp patterns
+                    - prefix/.*
+                    - prefix_.*
+                    - .*/suffix
+                    - .*_suffix
+                    - .*/contains/.*
+                    - .*_contains_.*
+                    - full/name/match
+                    - full_name_match
+    filter/exclude:
+        # any names matching filters are excluded from remainder of pipeline
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                    - .*/suffix
+                    - .*_suffix
+                    - .*/contains/.*
+                    - .*_contains_.*
+                    - full/name/match
+                    - full_name_match
+    filter/unlimitedcache:
+        metrics:
+            include:
+                match_type: regexp
+                regexp:
+                    cacheenabled: true
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                    - .*/suffix
+                    - .*_suffix
+                    - .*/contains/.*
+                    - .*_contains_.*
+                    - full/name/match
+                    - full_name_match
+    filter/limitedcache:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                    - .*/suffix
+                    - .*_suffix
+                    - .*/contains/.*
+                    - .*_contains_.*
+                    - full/name/match
+                    - full_name_match
+                regexp:
+                    cacheenabled: true
+                    cachemaxnumentries: 10
+    filter/fullmatchrequired:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - prefix/.*
+                    - prefix_.*
+                    - .*/suffix
+                    - .*_suffix
+                    - .*/contains/.*
+                    - .*_contains_.*
+                    - full/name/match
+                    - full_name_match
+                regexp:
+                    fullmatchrequired: true
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [filter]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [filter]
+            exporters: [exampleexporter]

--- a/processor/filterprocessor/testdata/config_strict.yaml
+++ b/processor/filterprocessor/testdata/config_strict.yaml
@@ -1,0 +1,59 @@
+receivers:
+    examplereceiver:
+
+processors:
+    filter/empty:
+        metrics:
+            include:
+                match_type: strict
+    filter/include:
+        metrics:
+            # any names NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+    filter/exclude:
+        metrics:
+            # any names matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+    filter/includeexclude:
+        metrics:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow metrics named "hello/world" to pass through
+            include:
+                match_type: strict
+                metric_names:
+                    - hello_world
+                    - hello/world
+            exclude:
+                match_type: strict
+                metric_names:
+                    - hello_world
+    filter/strictwithconfig:
+        metrics:
+            include:
+                match_type: strict
+                strict:
+                metric_names:
+                    - hello_world
+                    - hello/world
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [filter/empty]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [filter/empty]
+            exporters: [exampleexporter]

--- a/processor/processortest/caching_processor.go
+++ b/processor/processortest/caching_processor.go
@@ -1,0 +1,46 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package processortest
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+// CachingTraceConsumer is a dummy consumer that simply stores the trace data.
+// When testing processors, it can be specified as the next consumer of a processor
+// to inspect the outputs of the processor being tested.
+type CachingTraceConsumerOld struct {
+	Data consumerdata.TraceData
+}
+
+// ConsumeTraceData stores the trace data and returns nil.
+func (ctc *CachingTraceConsumerOld) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	ctc.Data = td
+	return nil
+}
+
+// CachingMetricsConsumer is a dummy consumer that simply stores the metrics data.
+// When testing processors, it can be specified as the next consumer of a processor
+// to inspect the outputs of the processor being tested.
+type CachingMetricsConsumer struct {
+	Data consumerdata.MetricsData
+}
+
+// ConsumeMetricData stores the metrics data and returns nil.
+func (cmc *CachingMetricsConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	cmc.Data = md
+	return nil
+}


### PR DESCRIPTION
**Description:** Add a filterprocessor that can filter (drop) metrics by metric names.

A similar processor can be done for trace spans, however that is not implemented with this PR.